### PR TITLE
make the token and control urls configurable

### DIFF
--- a/.github/workflows/publish-operator.yml
+++ b/.github/workflows/publish-operator.yml
@@ -1,0 +1,31 @@
+name: Publish Dev Operator
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish k8s-operator image
+        env:
+          REPO: ghcr.io/${{ github.repository_owner }}/tailscale
+          TAGS: ${{ github.ref_name }}
+        run: |
+          echo "Building and publishing to ${REPO} with tags ${TAGS}"
+          make publishdevoperator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -587,7 +587,6 @@ jobs:
       - android
       - test
       - windows
-      - vm
       - cross
       - ios
       - wasm


### PR DESCRIPTION
The first commit adds the changes for making the token and control url configurable.

The second is to make the pr mergable, since the vm test runs only in the tailscale repo: https://github.com/ninech/tailscale/blob/main/.github/workflows/test.yml#L202

The third commit is adding a workflow to build the operator when tagging the repo. Currently tailscale builds it internally and syncs it publicly.