### PR TITLE
allow to not append a dot for given FQDNs

### DIFF
--- a/cmd/k8s-operator/operator.go
+++ b/cmd/k8s-operator/operator.go
@@ -80,6 +80,9 @@ func main() {
 		// services exists. The default is to make sure that there are
 		// exactly 2 sub-domains in the FQDN.
 		relaxedDomainValidation = defaultBool("OPERATOR_RELAXED_DOMAIN_VALIDATION", false)
+		// noFqdnDotAppend prevents the dot ('.') appending to the FQDN
+		// of egress proxy services
+		noFqdnDotAppend = defaultBool("OPERATOR_NO_FQDN_DOT_APPEND", false)
 	)
 
 	var opts []kzap.Opts
@@ -124,6 +127,7 @@ func main() {
 			baseDomain:              baseDomain,
 			relaxedDomainValidation: relaxedDomainValidation,
 		},
+		noFqdnDotAppend: noFqdnDotAppend,
 	}
 	runReconcilers(rOpts)
 }
@@ -310,6 +314,7 @@ func runReconcilers(opts reconcilerOpts) {
 			clock:                 tstime.DefaultClock{},
 			defaultProxyClass:     opts.defaultProxyClass,
 			validationOpts:        opts.validationOpts,
+			noFqdnDotAppend:       opts.noFqdnDotAppend,
 		})
 	if err != nil {
 		startlog.Fatalf("could not create service reconciler: %v", err)
@@ -585,6 +590,9 @@ type reconcilerOpts struct {
 	// validationOpts are used to control validations happening in the
 	// reconcilers
 	validationOpts validationOpts
+	// noFqdnDotAppend prevents the addition of a dot ('.") to the end of
+	// destination FQDNs in egress proxies
+	noFqdnDotAppend bool
 }
 
 // enqueueAllIngressEgressProxySvcsinNS returns a reconcile request for each

--- a/cmd/k8s-operator/svc.go
+++ b/cmd/k8s-operator/svc.go
@@ -67,6 +67,8 @@ type ServiceReconciler struct {
 	defaultProxyClass string
 
 	validationOpts validationOpts
+
+	noFqdnDotAppend bool
 }
 
 var (
@@ -274,7 +276,7 @@ func (a *ServiceReconciler) maybeProvision(ctx context.Context, logger *zap.Suga
 		gaugeEgressProxies.Set(int64(a.managedEgressProxies.Len()))
 	} else if fqdn := svc.Annotations[AnnotationTailnetTargetFQDN]; fqdn != "" {
 		fqdn := svc.Annotations[AnnotationTailnetTargetFQDN]
-		if !strings.HasSuffix(fqdn, ".") {
+		if !strings.HasSuffix(fqdn, ".") && !a.noFqdnDotAppend {
 			fqdn = fqdn + "."
 		}
 		sts.TailnetTargetFQDN = fqdn


### PR DESCRIPTION
When comparing the node names to the received network peer map in "containerboot", it might be that network peers have no final dot appended to their FQDN. In that case, the operator should also not add a final dot to the FQDN. With the help of the OPERATOR_NO_FQDN_DOT_APPEND env variable this can be achieved and there will be no dot added to the content of the TS_TAILNET_TARGET_FQDN env variable which is read by "containerboot".