### PR TITLE
fix issue on empty configMap

### DIFF
--- a/cmd/k8s-nameserver/main.go
+++ b/cmd/k8s-nameserver/main.go
@@ -490,7 +490,9 @@ func configMapCacheReader(lister listersv1.ConfigMapLister) configReaderFunc {
 		if data, exists := cm.Data[configMapKey]; exists {
 			return []byte(data), nil
 		}
-		return nil, fmt.Errorf("configMap key %q does not exist", configMapKey)
+		// if the configMap is empty we need to return `nil` which will
+		// be handled by the caller specifically
+		return nil, nil
 	}
 }
 


### PR DESCRIPTION
If the configMap is empty we must not return an error but an empty byte slice instead as this will be handled specifically by the `resetRecords` function.