### PR TITLE
use at least 2 replicas for the nameserver

### DIFF
--- a/cmd/k8s-operator/deploy/manifests/nameserver/deploy.yaml
+++ b/cmd/k8s-operator/deploy/manifests/nameserver/deploy.yaml
@@ -3,13 +3,13 @@ kind: Deployment
 metadata:
   name: nameserver 
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: nameserver
   strategy:
-    type: Recreate
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -33,6 +33,13 @@ spec:
         volumeMounts:
         - name: dnsrecords
           mountPath: /config
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: nameserver
       restartPolicy: Always
       serviceAccount: nameserver
       serviceAccountName: nameserver


### PR DESCRIPTION
Currently there is just 1 replica of the nameserver being deployed. To allow for more availability, we increase to 2 and add try to spread the pods over multiple nodes.